### PR TITLE
Test Frontend coverage catch-up

### DIFF
--- a/frontend/src/api/blogApi.test.js
+++ b/frontend/src/api/blogApi.test.js
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { apiGet } from "./client";
+import { getBlogPost, getBlogPosts, getBlogPostsByTag } from "./blogApi";
+
+vi.mock("./client", () => ({
+  apiGet: vi.fn(),
+}));
+
+describe("blogApi", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("loads and maps blog posts", async () => {
+    apiGet.mockResolvedValue([{ id: 1, title: "First post" }]);
+
+    await expect(getBlogPosts()).resolves.toEqual([
+      expect.objectContaining({
+        id: 1,
+        title: "First post",
+      }),
+    ]);
+
+    expect(apiGet).toHaveBeenCalledWith("/blog/");
+  });
+
+  test("loads and maps blog posts by encoded tag", async () => {
+    apiGet.mockResolvedValue([{ id: 2, title: "Tagged post" }]);
+
+    await getBlogPostsByTag("React Testing");
+
+    expect(apiGet).toHaveBeenCalledWith("/blog/tag/React%20Testing/");
+  });
+
+  test("loads and maps a blog post by encoded slug", async () => {
+    apiGet.mockResolvedValue({ id: 3, title: "Detail post" });
+
+    await expect(getBlogPost("detail post")).resolves.toEqual(
+      expect.objectContaining({
+        id: 3,
+        title: "Detail post",
+      }),
+    );
+
+    expect(apiGet).toHaveBeenCalledWith("/blog/detail%20post/");
+  });
+});

--- a/frontend/src/api/blogMapper.test.js
+++ b/frontend/src/api/blogMapper.test.js
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+import { mapBlogPost, mapBlogPosts } from "./blogMapper";
+
+describe("mapBlogPost", () => {
+  test("maps nested blog post content from API field names", () => {
+    const blogPost = mapBlogPost({
+      id: 1,
+      title: "Testing Frontend Boundaries",
+      intro: "Intro text",
+      paragraphs: [
+        {
+          id: 10,
+          blog_post: 1,
+          heading: "Paragraph heading",
+          text: "Paragraph text",
+          snippets: [
+            {
+              id: 20,
+              paragraph: 10,
+              snippet: "const tested = true;",
+              side_scroll: true,
+              description: "Code sample",
+              intended_location: "after paragraph",
+            },
+            null,
+          ],
+        },
+      ],
+      tags: ["React", 42, "Testing"],
+      date_added: "2026-05-10",
+      slug: "testing-frontend-boundaries",
+    });
+
+    expect(blogPost).toEqual({
+      id: 1,
+      title: "Testing Frontend Boundaries",
+      intro: "Intro text",
+      paragraphs: [
+        {
+          id: 10,
+          blogPost: 1,
+          heading: "Paragraph heading",
+          text: "Paragraph text",
+          snippets: [
+            {
+              id: 20,
+              paragraph: 10,
+              snippet: "const tested = true;",
+              sideScroll: true,
+              description: "Code sample",
+              intendedLocation: "after paragraph",
+            },
+          ],
+        },
+      ],
+      tags: ["React", "Testing"],
+      dateAdded: "2026-05-10",
+      slug: "testing-frontend-boundaries",
+    });
+  });
+
+  test("maps camel case fallback fields", () => {
+    const blogPost = mapBlogPost({
+      paragraphs: [
+        {
+          blogPost: 2,
+          snippets: [
+            {
+              sideScroll: true,
+              intendedLocation: "inline",
+            },
+          ],
+        },
+      ],
+      dateAdded: "2026-05-11",
+    });
+
+    expect(blogPost.paragraphs[0].blogPost).toBe(2);
+    expect(blogPost.paragraphs[0].snippets[0].sideScroll).toBe(true);
+    expect(blogPost.paragraphs[0].snippets[0].intendedLocation).toBe("inline");
+    expect(blogPost.dateAdded).toBe("2026-05-11");
+  });
+
+  test("returns null for invalid blog post content", () => {
+    expect(mapBlogPost(null)).toBeNull();
+  });
+});
+
+describe("mapBlogPosts", () => {
+  test("maps arrays and filters invalid blog post entries", () => {
+    const blogPosts = mapBlogPosts([
+      {
+        id: 1,
+        title: "First post",
+      },
+      null,
+      {
+        id: 2,
+        title: "Second post",
+      },
+    ]);
+
+    expect(blogPosts).toHaveLength(2);
+    expect(blogPosts.map((blogPost) => blogPost.title)).toEqual(["First post", "Second post"]);
+  });
+
+  test("returns an empty array for invalid blog post lists", () => {
+    expect(mapBlogPosts(undefined)).toEqual([]);
+  });
+});

--- a/frontend/src/api/client.test.js
+++ b/frontend/src/api/client.test.js
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { apiGet } from "./client";
+
+describe("apiGet", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("prefixes API paths and returns parsed JSON", async () => {
+    const payload = { ok: true };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(payload),
+    });
+
+    await expect(apiGet("portfolio/")).resolves.toEqual(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/portfolio/");
+  });
+
+  test("does not duplicate the leading slash", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({}),
+    });
+
+    await apiGet("/core/context/");
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/core/context/");
+  });
+
+  test("throws a detailed error for unsuccessful responses", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: vi.fn().mockResolvedValue("Server error"),
+    });
+
+    await expect(apiGet("/broken/")).rejects.toThrow("GET /api/broken/ failed with 500: Server error");
+  });
+});

--- a/frontend/src/api/coreApi.test.js
+++ b/frontend/src/api/coreApi.test.js
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { apiGet } from "./client";
+import { getAbout, getCoreContext, getHero } from "./coreApi";
+
+vi.mock("./client", () => ({
+  apiGet: vi.fn(),
+}));
+
+describe("coreApi", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("loads and maps core context", async () => {
+    apiGet.mockResolvedValue({
+      domain_name: "example.dev",
+      site_owner: "Example Owner",
+      social_media_links: [],
+    });
+
+    await expect(getCoreContext()).resolves.toEqual({
+      domainName: "example.dev",
+      siteOwner: "Example Owner",
+      socialMediaLinks: [],
+      projectOverviewLimit: undefined,
+      blogOverviewLimit: undefined,
+    });
+
+    expect(apiGet).toHaveBeenCalledWith("/core/context/");
+  });
+
+  test("loads and maps hero content", async () => {
+    apiGet.mockResolvedValue({
+      headline: "Backend Developer",
+      intro: "Intro",
+      skills: ["Python"],
+    });
+
+    await expect(getHero()).resolves.toEqual({
+      id: null,
+      headline: "Backend Developer",
+      intro: "Intro",
+      skills: ["Python"],
+    });
+
+    expect(apiGet).toHaveBeenCalledWith("/hero/");
+  });
+
+  test("loads and maps about content", async () => {
+    apiGet.mockResolvedValue({
+      intro: "About intro",
+      mindset_intro: "Mindset",
+      mindset_list: ["Clear code"],
+    });
+
+    await expect(getAbout()).resolves.toMatchObject({
+      intro: "About intro",
+      mindsetIntro: "Mindset",
+      mindsetList: ["Clear code"],
+    });
+
+    expect(apiGet).toHaveBeenCalledWith("/about/");
+  });
+});

--- a/frontend/src/api/coreMapper.test.js
+++ b/frontend/src/api/coreMapper.test.js
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+import { mapAbout, mapCoreContext, mapHero } from "./coreMapper";
+
+describe("mapHero", () => {
+  test("maps hero content from API field names", () => {
+    const hero = mapHero({
+      id: 1,
+      headline: "Backend Developer",
+      intro: "I build maintainable services.",
+      skills: ["Python", "", "Django", 42],
+    });
+
+    expect(hero).toEqual({
+      id: 1,
+      headline: "Backend Developer",
+      intro: "I build maintainable services.",
+      skills: ["Python", "Django"],
+    });
+  });
+
+  test("returns an empty object for invalid hero content", () => {
+    expect(mapHero(null)).toEqual({});
+  });
+});
+
+describe("mapAbout", () => {
+  test("maps about page content from snake case API fields", () => {
+    const about = mapAbout({
+      id: 2,
+      intro: "About intro",
+      background: "Background text",
+      mindset_intro: "How I work",
+      mindset_list: ["Clear code", "", "Useful tests"],
+      focus_intro: "Current focus",
+      focus_list: ["Django", "React", null],
+    });
+
+    expect(about).toEqual({
+      id: 2,
+      intro: "About intro",
+      background: "Background text",
+      mindsetIntro: "How I work",
+      mindsetList: ["Clear code", "Useful tests"],
+      focusIntro: "Current focus",
+      focusList: ["Django", "React"],
+    });
+  });
+
+  test("maps legacy about intro text fallback", () => {
+    const about = mapAbout({
+      text: "Legacy about text",
+    });
+
+    expect(about.intro).toBe("Legacy about text");
+  });
+});
+
+describe("mapCoreContext", () => {
+  test("maps site context, social links, and overview limits from API field names", () => {
+    const coreContext = mapCoreContext({
+      domain_name: "example.dev",
+      site_owner: "Example Owner",
+      social_media_links: [
+        {
+          id: 1,
+          social_media: "GitHub",
+          url: "https://github.com/example",
+        },
+        null,
+        {
+          id: 2,
+          social_media: "LinkedIn",
+          url: "https://linkedin.com/in/example",
+        },
+      ],
+      project_overview_limit: 3,
+      blog_overview_limit: 2,
+    });
+
+    expect(coreContext).toEqual({
+      domainName: "example.dev",
+      siteOwner: "Example Owner",
+      socialMediaLinks: [
+        {
+          id: 1,
+          socialMedia: "GitHub",
+          url: "https://github.com/example",
+        },
+        {
+          id: 2,
+          socialMedia: "LinkedIn",
+          url: "https://linkedin.com/in/example",
+        },
+      ],
+      projectOverviewLimit: 3,
+      blogOverviewLimit: 2,
+    });
+  });
+
+  test("returns an empty object for invalid core context", () => {
+    expect(mapCoreContext(undefined)).toEqual({});
+  });
+});

--- a/frontend/src/api/mapperUtils.test.js
+++ b/frontend/src/api/mapperUtils.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { asArray, asBoolean, asNumber, asOptionalNumber, asString, isObject } from "./mapperUtils";
+
+describe("mapperUtils", () => {
+  test("detects plain objects", () => {
+    expect(isObject({ key: "value" })).toBe(true);
+    expect(isObject(null)).toBe(false);
+    expect(isObject(["value"])).toBe(false);
+    expect(isObject("value")).toBe(false);
+  });
+
+  test("coerces strings with fallbacks", () => {
+    expect(asString("value")).toBe("value");
+    expect(asString(42)).toBe("");
+    expect(asString(42, "fallback")).toBe("fallback");
+  });
+
+  test("coerces booleans with fallbacks", () => {
+    expect(asBoolean(true, false)).toBe(true);
+    expect(asBoolean("true", false)).toBe(false);
+  });
+
+  test("coerces numbers with fallbacks", () => {
+    expect(asNumber(5)).toBe(5);
+    expect(asNumber("5")).toBe(0);
+    expect(asNumber("5", 10)).toBe(10);
+  });
+
+  test("coerces optional numbers", () => {
+    expect(asOptionalNumber(5)).toBe(5);
+    expect(asOptionalNumber("5")).toBeUndefined();
+  });
+
+  test("coerces arrays", () => {
+    expect(asArray(["value"])).toEqual(["value"]);
+    expect(asArray("value")).toEqual([]);
+  });
+});

--- a/frontend/src/api/projectsApi.test.js
+++ b/frontend/src/api/projectsApi.test.js
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { apiGet } from "./client";
+import { getPortfolioContext, getProject, getProjects, getProjectsByFeatured } from "./projectsApi";
+
+vi.mock("./client", () => ({
+  apiGet: vi.fn(),
+}));
+
+describe("projectsApi", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("loads and maps projects", async () => {
+    apiGet.mockResolvedValue([{ id: 1, title: "Project", repo_url: "https://github.com/example/project" }]);
+
+    await expect(getProjects()).resolves.toEqual([
+      expect.objectContaining({
+        id: 1,
+        title: "Project",
+        repoUrl: "https://github.com/example/project",
+      }),
+    ]);
+
+    expect(apiGet).toHaveBeenCalledWith("/portfolio/");
+  });
+
+  test("loads and maps projects by featured state", async () => {
+    apiGet.mockResolvedValue([]);
+
+    await getProjectsByFeatured(true);
+
+    expect(apiGet).toHaveBeenCalledWith("/portfolio/?featured=true");
+  });
+
+  test("loads and maps a project by encoded slug", async () => {
+    apiGet.mockResolvedValue({ id: 2, title: "Project Detail", slug: "project detail" });
+
+    await getProject("project detail");
+
+    expect(apiGet).toHaveBeenCalledWith("/portfolio/project%20detail/");
+  });
+
+  test("loads and maps portfolio context", async () => {
+    apiGet.mockResolvedValue({ id: 3, intro: "Portfolio intro" });
+
+    await expect(getPortfolioContext()).resolves.toEqual({
+      id: 3,
+      intro: "Portfolio intro",
+    });
+
+    expect(apiGet).toHaveBeenCalledWith("/portfolio/context");
+  });
+});

--- a/frontend/src/components/core/HeroSection.test.jsx
+++ b/frontend/src/components/core/HeroSection.test.jsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import HeroSection from "./HeroSection";
+
+describe("HeroSection", () => {
+  test("renders headline, intro, skills, and actions", () => {
+    render(
+      <HeroSection
+        headline="Portfolio"
+        intro={"First line\nSecond line"}
+        skills={["Python", "Django"]}
+        actions={<a href="/portfolio/">View portfolio</a>}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Portfolio" })).toBeInTheDocument();
+    expect(screen.getByText((_, element) => element.textContent === "First lineSecond line")).toBeInTheDocument();
+    expect(screen.getByRole("list", { name: "Core technologies" })).toBeInTheDocument();
+    expect(screen.getByText("Python")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View portfolio" })).toHaveAttribute("href", "/portfolio/");
+  });
+
+  test("renders custom visual content when provided", () => {
+    render(<HeroSection headline="Project" intro="Intro" visual={<img src="/media/project.png" alt="Project visual" />} />);
+
+    expect(screen.getByRole("img", { name: "Project visual" })).toHaveAttribute("src", "/media/project.png");
+  });
+});

--- a/frontend/src/components/layout/Footer.test.jsx
+++ b/frontend/src/components/layout/Footer.test.jsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { CoreContext } from "../../context/CoreContext";
+import Footer from "./Footer";
+
+describe("Footer", () => {
+  test("renders copyright and social links from core context", () => {
+    render(
+      <CoreContext.Provider
+        value={{
+          coreContext: {
+            siteOwner: "Example Owner",
+            socialMediaLinks: [{ id: 1, socialMedia: "gh", url: "https://github.com/example" }],
+          },
+          error: null,
+          isLoading: false,
+        }}
+      >
+        <Footer />
+      </CoreContext.Provider>,
+    );
+
+    expect(screen.getByText(new RegExp(`© ${new Date().getFullYear()} Example Owner`))).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "GitHub" })).toHaveAttribute("href", "https://github.com/example");
+  });
+});

--- a/frontend/src/components/layout/Header.test.jsx
+++ b/frontend/src/components/layout/Header.test.jsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test } from "vitest";
+import { CoreContext } from "../../context/CoreContext";
+import Header from "./Header";
+
+function renderHeader() {
+  return render(
+    <CoreContext.Provider value={{ coreContext: { domainName: "example.dev" }, error: null, isLoading: false }}>
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    </CoreContext.Provider>,
+  );
+}
+
+describe("Header", () => {
+  test("renders the domain home link", () => {
+    renderHeader();
+
+    expect(screen.getByRole("link", { name: "example.dev" })).toHaveAttribute("href", "/");
+  });
+
+  test("toggles and closes the mobile menu", () => {
+    const { container } = renderHeader();
+    const button = screen.getByRole("button", { name: "Toggle navigation menu" });
+
+    fireEvent.click(button);
+
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(container.querySelector(".nav-menu")).toHaveClass("active");
+
+    fireEvent.click(screen.getByRole("link", { name: "Portfolio" }));
+
+    expect(button).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/frontend/src/components/layout/Layout.test.jsx
+++ b/frontend/src/components/layout/Layout.test.jsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, test } from "vitest";
+import { CoreContext } from "../../context/CoreContext";
+import Layout from "./Layout";
+
+describe("Layout", () => {
+  test("renders header, breadcrumb, outlet content, and footer", () => {
+    render(
+      <CoreContext.Provider
+        value={{
+          coreContext: {
+            domainName: "Example.dev",
+            siteOwner: "Example Owner",
+            socialMediaLinks: [],
+          },
+          error: null,
+          isLoading: false,
+        }}
+      >
+        <MemoryRouter initialEntries={["/portfolio/"]}>
+          <Routes>
+            <Route element={<Layout />}>
+              <Route path="/portfolio/" element={<p>Outlet content</p>} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </CoreContext.Provider>,
+    );
+
+    expect(screen.getByRole("link", { name: "Example.dev" })).toHaveAttribute("href", "/");
+    expect(screen.getByText("guest@example.dev")).toBeInTheDocument();
+    expect(screen.getByText("~/portfolio/")).toBeInTheDocument();
+    expect(screen.getByText("Outlet content")).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(`© ${new Date().getFullYear()} Example Owner`))).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/NavLinks.test.jsx
+++ b/frontend/src/components/layout/NavLinks.test.jsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+import NavLinks from "./NavLinks";
+
+function renderNavLinks(path = "/portfolio/", props = {}) {
+  const onNavigate = vi.fn();
+
+  const renderResult = render(
+    <MemoryRouter initialEntries={[path]}>
+      <NavLinks isMenuOpen={false} onNavigate={onNavigate} {...props} />
+    </MemoryRouter>,
+  );
+
+  return { onNavigate, ...renderResult };
+}
+
+describe("NavLinks", () => {
+  test("marks the current route", () => {
+    renderNavLinks("/portfolio/");
+
+    expect(screen.getByRole("link", { name: "Portfolio" })).toHaveClass("current");
+  });
+
+  test("hides the home link on the home page", () => {
+    renderNavLinks("/");
+
+    expect(screen.queryByRole("link", { name: "Home" })).not.toBeInTheDocument();
+  });
+
+  test("calls onNavigate when a link is clicked", () => {
+    const { onNavigate } = renderNavLinks("/portfolio/");
+
+    fireEvent.click(screen.getByRole("link", { name: "Blog" }));
+
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+
+  test("applies active class when the menu is open", () => {
+    const { container } = renderNavLinks("/portfolio/", { isMenuOpen: true });
+
+    expect(container.querySelector(".nav-menu")).toHaveClass("active");
+  });
+});

--- a/frontend/src/components/layout/SocialMediaLinks.test.jsx
+++ b/frontend/src/components/layout/SocialMediaLinks.test.jsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { CoreContext } from "../../context/CoreContext";
+import SocialMediaLinks from "./SocialMediaLinks";
+
+function renderWithCoreContext(ui, socialMediaLinks = []) {
+  return render(
+    <CoreContext.Provider value={{ coreContext: { socialMediaLinks }, error: null, isLoading: false }}>
+      {ui}
+    </CoreContext.Provider>,
+  );
+}
+
+describe("SocialMediaLinks", () => {
+  test("renders supported links from explicit props", () => {
+    renderWithCoreContext(
+      <SocialMediaLinks
+        links={[
+          { id: 1, socialMedia: "gh", url: "https://github.com/example" },
+          { id: 2, socialMedia: "unknown", url: "https://example.com" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "GitHub" })).toHaveAttribute("href", "https://github.com/example");
+    expect(screen.queryByRole("link", { name: "unknown" })).not.toBeInTheDocument();
+  });
+
+  test("renders links from core context when explicit links are not provided", () => {
+    renderWithCoreContext(<SocialMediaLinks />, [
+      { id: 1, socialMedia: "in", url: "https://linkedin.com/in/example" },
+    ]);
+
+    expect(screen.getByRole("link", { name: "LinkedIn" })).toHaveAttribute("href", "https://linkedin.com/in/example");
+  });
+
+  test("renders nothing when there are no social media links", () => {
+    const { container } = renderWithCoreContext(<SocialMediaLinks />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/portfolio/ProjectCard.test.jsx
+++ b/frontend/src/components/portfolio/ProjectCard.test.jsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test } from "vitest";
+import { CoreContext } from "../../context/CoreContext";
+import ProjectCard from "./ProjectCard";
+
+function createProject(project = {}) {
+  return {
+    id: 1,
+    title: "Project One",
+    repoUrl: "https://github.com/example/project-one",
+    liveUrl: "https://example.com/project-one",
+    description: "Project summary",
+    slug: "project-one",
+    featured: true,
+    techStack: ["React", "Django"],
+    ...project,
+  };
+}
+
+function renderProjectCard(project = createProject(), props = {}) {
+  return render(
+    <CoreContext.Provider value={{ coreContext: { socialMediaLinks: [] }, error: null, isLoading: false }}>
+      <MemoryRouter>
+        <ProjectCard project={project} {...props} />
+      </MemoryRouter>
+    </CoreContext.Provider>,
+  );
+}
+
+describe("ProjectCard", () => {
+  test("renders project summary, tech tags, and detail link", () => {
+    renderProjectCard();
+
+    expect(screen.getByRole("heading", { name: "Project One" })).toBeInTheDocument();
+    expect(screen.getByText("Project summary")).toBeInTheDocument();
+    expect(screen.getByText("React")).toBeInTheDocument();
+    expect(screen.getByText("Django")).toBeInTheDocument();
+    expect(screen.getByLabelText("Project One")).toHaveAttribute("href", "/portfolio/project-one/");
+  });
+
+  test("renders repo and live links when available", () => {
+    renderProjectCard();
+
+    expect(screen.getByRole("link", { name: /GitHub/ })).toHaveAttribute(
+      "href",
+      "https://github.com/example/project-one",
+    );
+    expect(screen.getByRole("link", { name: /Live demo/ })).toHaveAttribute("href", "https://example.com/project-one");
+  });
+
+  test("uses a placeholder tech tag when tech stack is empty", () => {
+    renderProjectCard(createProject({ techStack: [] }));
+
+    expect(screen.getByText("Project tech stack TBD")).toBeInTheDocument();
+  });
+
+  test("renders featured badge only for featured CTA cards", () => {
+    renderProjectCard(createProject({ featured: true }), { ctaCard: true });
+
+    expect(screen.getByText("Featured")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/portfolio/ProjectsSection.test.jsx
+++ b/frontend/src/components/portfolio/ProjectsSection.test.jsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test } from "vitest";
+import { CoreContext } from "../../context/CoreContext";
+import ProjectsSection from "./ProjectsSection";
+
+function createProject(project = {}) {
+  return {
+    id: 1,
+    title: "Project One",
+    repoUrl: "https://github.com/example/project-one",
+    liveUrl: "",
+    description: "Project summary",
+    slug: "project-one",
+    featured: false,
+    techStack: ["React"],
+    ...project,
+  };
+}
+
+function renderProjectsSection(projects, props = {}) {
+  return render(
+    <CoreContext.Provider value={{ coreContext: { socialMediaLinks: [] }, error: null, isLoading: false }}>
+      <MemoryRouter>
+        <ProjectsSection projects={projects} {...props} />
+      </MemoryRouter>
+    </CoreContext.Provider>,
+  );
+}
+
+describe("ProjectsSection", () => {
+  test("renders featured project section when the first project is featured", () => {
+    renderProjectsSection([createProject({ featured: true })], { ctaCards: true });
+
+    expect(screen.getByRole("heading", { name: "Featured Projects" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /View all featured/ })).toHaveAttribute("href", "#featured-projects");
+    expect(screen.getByRole("heading", { name: "Project One" })).toBeInTheDocument();
+  });
+
+  test("renders other project section for non-featured projects", () => {
+    renderProjectsSection([createProject({ featured: false })], { tight: true });
+
+    expect(screen.getByRole("heading", { name: "Other Projects" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /View all projects/ })).toHaveAttribute("href", "#other-projects");
+  });
+
+  test("treats highlighted projects as featured for legacy mapped data", () => {
+    renderProjectsSection([createProject({ featured: false, highlighted: true })]);
+
+    expect(screen.getByRole("heading", { name: "Featured Projects" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/config/overviewLimits.test.js
+++ b/frontend/src/config/overviewLimits.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { getBlogOverviewLimit, getProjectOverviewLimit, limitOverviewItems } from "./overviewLimits";
+
+describe("overviewLimits", () => {
+  test("limits overview items", () => {
+    expect(limitOverviewItems(["one", "two", "three"], 2)).toEqual(["one", "two"]);
+  });
+
+  test("uses configured project overview limits", () => {
+    expect(getProjectOverviewLimit({ projectOverviewLimit: 5 })).toBe(5);
+  });
+
+  test("uses configured blog overview limits", () => {
+    expect(getBlogOverviewLimit({ blogOverviewLimit: 4 })).toBe(4);
+  });
+
+  test("falls back for missing, negative, and non-integer limits", () => {
+    expect(getProjectOverviewLimit(null)).toBe(3);
+    expect(getProjectOverviewLimit({ projectOverviewLimit: -1 })).toBe(3);
+    expect(getBlogOverviewLimit({ blogOverviewLimit: 1.5 })).toBe(2);
+  });
+});

--- a/frontend/src/context/CoreContextProvider.test.jsx
+++ b/frontend/src/context/CoreContextProvider.test.jsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getCoreContext } from "../api/coreApi";
+import { CoreContextProvider } from "./CoreContextProvider";
+import { useCoreContext } from "./useCoreContext";
+
+vi.mock("../api/coreApi", () => ({
+  getCoreContext: vi.fn(),
+}));
+
+function ContextState() {
+  const { coreContext, error, isLoading } = useCoreContext();
+
+  if (isLoading) {
+    return <p>Loading</p>;
+  }
+
+  if (error) {
+    return <p>Failed</p>;
+  }
+
+  return <p>{coreContext.domainName}</p>;
+}
+
+describe("CoreContextProvider", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("loads and provides core context", async () => {
+    getCoreContext.mockResolvedValue({ domainName: "example.dev" });
+
+    render(
+      <CoreContextProvider>
+        <ContextState />
+      </CoreContextProvider>,
+    );
+
+    expect(screen.getByText("Loading")).toBeInTheDocument();
+    expect(await screen.findByText("example.dev")).toBeInTheDocument();
+  });
+
+  test("provides error state when core context loading fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    getCoreContext.mockRejectedValue(new Error("Failed"));
+
+    render(
+      <CoreContextProvider>
+        <ContextState />
+      </CoreContextProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed")).toBeInTheDocument();
+    });
+
+    console.error.mockRestore();
+  });
+});

--- a/frontend/src/context/useCoreContext.test.jsx
+++ b/frontend/src/context/useCoreContext.test.jsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { CoreContext } from "./CoreContext";
+import { useCoreContext } from "./useCoreContext";
+
+function ContextConsumer() {
+  const { coreContext } = useCoreContext();
+  return <p>{coreContext.domainName}</p>;
+}
+
+describe("useCoreContext", () => {
+  test("returns context values from CoreContext", () => {
+    render(
+      <CoreContext.Provider value={{ coreContext: { domainName: "example.dev" }, error: null, isLoading: false }}>
+        <ContextConsumer />
+      </CoreContext.Provider>,
+    );
+
+    expect(screen.getByText("example.dev")).toBeInTheDocument();
+  });
+
+  test("throws when used outside CoreContextProvider", () => {
+    expect(() => render(<ContextConsumer />)).toThrow("useCoreContext must be used inside CoreContextProvider");
+  });
+});

--- a/frontend/src/hooks/usePageTitle.test.jsx
+++ b/frontend/src/hooks/usePageTitle.test.jsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { CoreContext } from "../context/CoreContext";
+import { usePageTitle } from "./usePageTitle";
+
+function PageTitleHarness({ pageTitle }) {
+  usePageTitle(pageTitle);
+  return null;
+}
+
+function renderWithCoreContext(pageTitle, coreContext = { domainName: "example.dev" }) {
+  return render(
+    <CoreContext.Provider value={{ coreContext, error: null, isLoading: false }}>
+      <PageTitleHarness pageTitle={pageTitle} />
+    </CoreContext.Provider>,
+  );
+}
+
+describe("usePageTitle", () => {
+  test("sets a page-specific document title with the domain name", () => {
+    renderWithCoreContext("Portfolio");
+
+    expect(document.title).toBe("Portfolio | example.dev");
+  });
+
+  test("sets the document title to the domain name when no page title is provided", () => {
+    renderWithCoreContext("");
+
+    expect(document.title).toBe("example.dev");
+  });
+
+  test("leaves the current document title unchanged until the domain name is available", () => {
+    document.title = "Existing title";
+
+    renderWithCoreContext("Portfolio", null);
+
+    expect(document.title).toBe("Existing title");
+  });
+});

--- a/frontend/src/pages/AboutPage.test.jsx
+++ b/frontend/src/pages/AboutPage.test.jsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getAbout } from "../api/coreApi";
+import { CoreContext } from "../context/CoreContext";
+import AboutPage from "./AboutPage";
+
+vi.mock("../api/coreApi", () => ({
+  getAbout: vi.fn(),
+}));
+
+vi.mock("../hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+function renderAboutPage() {
+  return render(
+    <CoreContext.Provider value={{ coreContext: { socialMediaLinks: [] }, error: null, isLoading: false }}>
+      <AboutPage />
+    </CoreContext.Provider>,
+  );
+}
+
+describe("AboutPage", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("renders about content loaded from the API", async () => {
+    getAbout.mockResolvedValue({
+      intro: "About intro",
+      background: "Background text",
+      mindsetIntro: "How I work intro",
+      mindsetList: ["Write clear code", "Test useful behavior"],
+      focusIntro: "Current focus intro",
+      focusList: ["Django", "React"],
+    });
+
+    renderAboutPage();
+
+    expect(await screen.findByRole("heading", { name: "About" })).toBeInTheDocument();
+    expect(screen.getByText("About intro")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "1. Background" })).toBeInTheDocument();
+    expect(screen.getByText("Write clear code")).toBeInTheDocument();
+    expect(screen.getByText("Django")).toBeInTheDocument();
+  });
+
+  test("renders placeholders and an error message when loading fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    getAbout.mockRejectedValue(new Error("Failed"));
+
+    renderAboutPage();
+
+    expect(await screen.findByText("Could not load about content.")).toBeInTheDocument();
+    expect(screen.getByText("About intro TBD")).toBeInTheDocument();
+
+    console.error.mockRestore();
+  });
+});

--- a/frontend/src/pages/BlogPostDetailPage.test.jsx
+++ b/frontend/src/pages/BlogPostDetailPage.test.jsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getBlogPost } from "../api/blogApi";
+import BlogPostDetailPage from "./BlogPostDetailPage";
+
+vi.mock("../api/blogApi", () => ({
+  getBlogPost: vi.fn(),
+}));
+
+vi.mock("../hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+function renderBlogPostDetailPage(path = "/blog/first-post") {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/blog/:slug" element={<BlogPostDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("BlogPostDetailPage", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("renders blog post details, tags, paragraphs, and snippets", async () => {
+    getBlogPost.mockResolvedValue({
+      title: "First Post",
+      intro: "Intro text",
+      tags: ["React Testing"],
+      paragraphs: [
+        {
+          id: 1,
+          heading: "Paragraph heading",
+          text: "Paragraph text",
+          snippets: [
+            {
+              id: 2,
+              intendedLocation: "Example",
+              snippet: "const value = true;",
+              sideScroll: true,
+              description: "Snippet description",
+            },
+          ],
+        },
+      ],
+    });
+
+    renderBlogPostDetailPage();
+
+    expect(await screen.findByRole("heading", { name: "First Post" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "React Testing" })).toHaveAttribute("href", "/blog/tag/react-testing/");
+    expect(screen.getByRole("heading", { name: "Paragraph heading" })).toBeInTheDocument();
+    expect(screen.getByText("const value = true;")).toHaveClass("scroll");
+  });
+
+  test("copies snippet content with the Clipboard API", async () => {
+    const writeText = vi.fn().mockResolvedValue();
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+    getBlogPost.mockResolvedValue({
+      title: "First Post",
+      intro: "Intro text",
+      tags: [],
+      paragraphs: [
+        {
+          id: 1,
+          heading: "Paragraph heading",
+          text: "Paragraph text",
+          snippets: [{ id: 2, snippet: "copy me" }],
+        },
+      ],
+    });
+
+    renderBlogPostDetailPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Copy snippet" }));
+
+    expect(writeText).toHaveBeenCalledWith("copy me");
+  });
+
+  test("renders loading and error states", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    getBlogPost.mockRejectedValue(new Error("Failed"));
+
+    renderBlogPostDetailPage();
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(await screen.findByText("Could not load blog post.")).toBeInTheDocument();
+
+    console.error.mockRestore();
+  });
+});

--- a/frontend/src/pages/BlogPostListPage.test.jsx
+++ b/frontend/src/pages/BlogPostListPage.test.jsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getBlogPosts, getBlogPostsByTag } from "../api/blogApi";
+import BlogPostListPage from "./BlogPostListPage";
+
+vi.mock("../api/blogApi", () => ({
+  getBlogPosts: vi.fn(),
+  getBlogPostsByTag: vi.fn(),
+}));
+
+vi.mock("../hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+function createBlogPost(blogPost = {}) {
+  return {
+    id: 1,
+    title: "First Post",
+    intro: "First post intro",
+    slug: "first-post",
+    tags: ["React Testing", "Django"],
+    ...blogPost,
+  };
+}
+
+function renderBlogPostListPage(path = "/blog/") {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/blog/" element={<BlogPostListPage />} />
+        <Route path="/blog/tag/:tag/" element={<BlogPostListPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("BlogPostListPage", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("renders blog posts and tag navigation", async () => {
+    getBlogPosts.mockResolvedValue([createBlogPost()]);
+
+    renderBlogPostListPage();
+
+    expect(await screen.findByRole("heading", { name: /First Post/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /React Testing/ })).toHaveAttribute("href", "/blog/tag/react-testing/");
+  });
+
+  test("loads filtered posts by tag and can remove the selected filter", async () => {
+    getBlogPostsByTag.mockResolvedValue([createBlogPost()]);
+    getBlogPosts.mockResolvedValue([createBlogPost()]);
+
+    renderBlogPostListPage("/blog/tag/react-testing/");
+
+    expect(await screen.findByRole("heading", { name: "React Testing" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Remove tag filter" })).toHaveAttribute("href", "/blog/");
+    expect(getBlogPostsByTag).toHaveBeenCalledWith("react-testing");
+  });
+
+  test("toggles the tags menu", async () => {
+    getBlogPosts.mockResolvedValue([createBlogPost()]);
+
+    const { container } = renderBlogPostListPage();
+
+    const button = await screen.findByRole("button", { name: "Toggle tags menu" });
+    fireEvent.click(button);
+
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(container.querySelector("#tags-menu")).toHaveClass("active");
+  });
+
+  test("renders an error message when posts fail to load", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    getBlogPosts.mockRejectedValue(new Error("Failed"));
+
+    renderBlogPostListPage();
+
+    expect(await screen.findByText("Could not load blog posts.")).toBeInTheDocument();
+
+    console.error.mockRestore();
+  });
+});

--- a/frontend/src/pages/HomePage.test.jsx
+++ b/frontend/src/pages/HomePage.test.jsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getBlogPosts } from "../api/blogApi";
+import { getHero } from "../api/coreApi";
+import { getProjectsByFeatured } from "../api/projectsApi";
+import { CoreContext } from "../context/CoreContext";
+import HomePage from "./HomePage";
+
+vi.mock("../api/blogApi", () => ({
+  getBlogPosts: vi.fn(),
+}));
+
+vi.mock("../api/coreApi", () => ({
+  getHero: vi.fn(),
+}));
+
+vi.mock("../api/projectsApi", () => ({
+  getProjectsByFeatured: vi.fn(),
+}));
+
+vi.mock("../hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+function renderHomePage(coreContext = { projectOverviewLimit: 1, blogOverviewLimit: 1, socialMediaLinks: [] }) {
+  return render(
+    <CoreContext.Provider value={{ coreContext, error: null, isLoading: false }}>
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    </CoreContext.Provider>,
+  );
+}
+
+describe("HomePage", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("loads hero, featured projects, and latest writing", async () => {
+    getHero.mockResolvedValue({ headline: "Backend Developer", intro: "Hero intro", skills: ["Python"] });
+    getProjectsByFeatured.mockResolvedValue([
+      {
+        id: 1,
+        title: "Featured Project",
+        repoUrl: "https://github.com/example/featured-project",
+        description: "Featured project summary",
+        slug: "featured-project",
+        featured: true,
+        techStack: ["Django"],
+      },
+    ]);
+    getBlogPosts.mockResolvedValue([
+      {
+        id: 2,
+        title: "Latest Post",
+        intro: "Latest post intro",
+        slug: "latest-post",
+        dateAdded: "2026-05-10",
+      },
+    ]);
+
+    renderHomePage();
+
+    expect(await screen.findByRole("heading", { name: "Backend Developer" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Featured Project" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Latest Post" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /View Portfolio/ })).toHaveAttribute("href", "/portfolio/");
+  });
+
+  test("renders fallback messages when projects and writing fail to load", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    getHero.mockResolvedValue({});
+    getProjectsByFeatured.mockRejectedValue(new Error("Projects failed"));
+    getBlogPosts.mockRejectedValue(new Error("Blog failed"));
+
+    renderHomePage();
+
+    expect(await screen.findByText("Hero headline TBD")).toBeInTheDocument();
+    expect(await screen.findByText("Could not load projects.")).toBeInTheDocument();
+    expect(await screen.findByText("Could not load writing.")).toBeInTheDocument();
+
+    console.error.mockRestore();
+  });
+});

--- a/frontend/src/pages/PortfolioPage.test.jsx
+++ b/frontend/src/pages/PortfolioPage.test.jsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getPortfolioContext, getProjectsByFeatured } from "../api/projectsApi";
+import { CoreContext } from "../context/CoreContext";
+import PortfolioPage from "./PortfolioPage";
+
+vi.mock("../api/projectsApi", () => ({
+  getPortfolioContext: vi.fn(),
+  getProjectsByFeatured: vi.fn(),
+}));
+
+vi.mock("../hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+function createProject(project = {}) {
+  return {
+    id: 1,
+    title: "Project One",
+    repoUrl: "https://github.com/example/project-one",
+    liveUrl: "",
+    description: "Project summary",
+    slug: "project-one",
+    featured: true,
+    techStack: ["React"],
+    ...project,
+  };
+}
+
+function renderPortfolioPage(coreContext = { projectOverviewLimit: 1, socialMediaLinks: [] }) {
+  return render(
+    <CoreContext.Provider value={{ coreContext, error: null, isLoading: false }}>
+      <MemoryRouter>
+        <PortfolioPage />
+      </MemoryRouter>
+    </CoreContext.Provider>,
+  );
+}
+
+describe("PortfolioPage", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("loads portfolio context and project sections", async () => {
+    getPortfolioContext.mockResolvedValue({ intro: "Portfolio intro" });
+    getProjectsByFeatured.mockImplementation((featured) =>
+      Promise.resolve(
+        featured
+          ? [createProject({ id: 1, title: "Featured Project", featured: true })]
+          : [createProject({ id: 2, title: "Other Project", featured: false, slug: "other-project" })],
+      ),
+    );
+
+    renderPortfolioPage();
+
+    expect(await screen.findByText("Portfolio intro")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Featured Projects" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Other Projects" })).toBeInTheDocument();
+    expect(getProjectsByFeatured).toHaveBeenCalledWith(true);
+    expect(getProjectsByFeatured).toHaveBeenCalledWith(false);
+  });
+
+  test("renders an error message when project loading fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    getPortfolioContext.mockResolvedValue({ intro: "Portfolio intro" });
+    getProjectsByFeatured.mockRejectedValue(new Error("Failed"));
+
+    renderPortfolioPage();
+
+    expect(await screen.findByText("Could not load projects.")).toBeInTheDocument();
+
+    console.error.mockRestore();
+  });
+});

--- a/frontend/src/pages/StatusPages.test.jsx
+++ b/frontend/src/pages/StatusPages.test.jsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import Status404Page from "./Status404Page";
+import Status500Page from "./Status500Page";
+
+vi.mock("../hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+describe("status pages", () => {
+  test("renders the 404 status page", () => {
+    render(<Status404Page />);
+
+    expect(screen.getByRole("heading", { name: "Requested page can't be found" })).toBeInTheDocument();
+    expect(screen.getByText("404")).toBeInTheDocument();
+  });
+
+  test("renders the 500 status page", () => {
+    render(<Status500Page />);
+
+    expect(screen.getByRole("heading", { name: "There has been an internal error" })).toBeInTheDocument();
+    expect(screen.getByText("500")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes/paths.test.js
+++ b/frontend/src/routes/paths.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { ROUTES, buildRoute } from "./paths";
+
+describe("ROUTES", () => {
+  test("defines application route patterns", () => {
+    expect(ROUTES).toEqual({
+      home: "/",
+      portfolio: "/portfolio/",
+      projectDetail: "/portfolio/:slug",
+      blog: "/blog/",
+      blogTag: "/blog/tag/:tag",
+      blogPostDetail: "/blog/:slug",
+      about: "/about/",
+      status500: "/500/",
+      notFound: "*",
+    });
+  });
+});
+
+describe("buildRoute", () => {
+  test("builds encoded detail routes", () => {
+    expect(buildRoute.projectDetail("project one")).toBe("/portfolio/project%20one/");
+    expect(buildRoute.blogTag("React Testing")).toBe("/blog/tag/React%20Testing/");
+    expect(buildRoute.blogPostDetail("post one")).toBe("/blog/post%20one/");
+  });
+
+  test("builds static blog route", () => {
+    expect(buildRoute.blog()).toBe("/blog/");
+  });
+});

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,1 +1,7 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/src/utils/renderLinebreaks.test.jsx
+++ b/frontend/src/utils/renderLinebreaks.test.jsx
@@ -1,0 +1,16 @@
+import { render } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { renderLinebreaks } from "./renderLinebreaks";
+
+describe("renderLinebreaks", () => {
+  test("renders line breaks between text lines", () => {
+    const { container } = render(<p>{renderLinebreaks("First line\nSecond line")}</p>);
+
+    expect(container).toHaveTextContent("First lineSecond line");
+    expect(container.querySelectorAll("br")).toHaveLength(1);
+  });
+
+  test("returns null for empty content", () => {
+    expect(renderLinebreaks("")).toBeNull();
+  });
+});

--- a/frontend/src/utils/slugifyTag.test.js
+++ b/frontend/src/utils/slugifyTag.test.js
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "vitest";
+import { slugifyTag } from "./slugifyTag";
+
+describe("slugifyTag", () => {
+  test("lowercases and hyphenates tag names", () => {
+    expect(slugifyTag("React Testing")).toBe("react-testing");
+  });
+
+  test("trims leading and trailing separators", () => {
+    expect(slugifyTag("  Python + Django! ")).toBe("python-django");
+  });
+});


### PR DESCRIPTION
## Summary

Adds frontend test coverage for existing implemented behavior.

Covered areas:

- API client and API wrapper modules
- Core, blog, and portfolio mappers
- Route builders
- Shared utilities and overview limit helpers
- Core context provider and hooks
- Layout components
- Portfolio components
- Implemented pages and status pages

The tests use Vitest, React Testing Library, jest-dom matchers, and jsdom.

## Notes

- This is a test coverage catch-up branch.
- Production behavior is not intentionally changed.
- Root `Pipfile` and `Pipfile.lock` are local LSP helper files and are not part of this PR.

## Verification

```bash
npm test
npm run lint
npm run build
```

All passed locally.