### PR TITLE
Configure Nginx domain from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Copy this file to `.env` and replace every `<...>` placeholder.
+
+# Site identity context rendered in the frontend.
+DOMAIN_NAME=<portfolio.example.com>
+SITE_OWNER=<site-owner>
+
+# Used by Nginx for `server_name` and by Certbot for the certificate paths.
+DOMAIN=<portfolio.example.com>
+
+# Certbot account contact.
+EMAIL=<admin@example.com>
+
+# Django settings.
+SECRET_KEY=<django-secret-key>
+DEBUG=<False>
+DJANGO_ALLOWED_HOSTS="<portfolio.example.com> <www.portfolio.example.com>"
+DJANGO_CSRF_TRUSTED_ORIGINS="https://<portfolio.example.com> https://<www.portfolio.example.com>"
+DJANGO_CORS_ALLOWED_ORIGINS="https://<portfolio.example.com> https://<www.portfolio.example.com>"
+
+# Database connection used by Django.
+SQL_ENGINE=<django.db.backends.postgresql>
+SQL_DATABASE=<database-name>
+SQL_USER=<database-user>
+SQL_PASSWORD=<database-password>
+SQL_HOST=<db>
+SQL_PORT=<5432>
+
+# PostgreSQL container initialization.
+POSTGRES_USER=<database-user>
+POSTGRES_PASSWORD=<database-password>
+POSTGRES_DB=<database-name>

--- a/README.md
+++ b/README.md
@@ -140,35 +140,14 @@ Docker volumes are used for:
 
 ## Environment Configuration
 
-Create a `.env` file in the project root and provide values for:
+The repository includes `.env.example` as the tracked documentation template for production and Docker Compose settings.
+Copy it to `.env`, then replace every `<...>` placeholder with the deployment value:
 
-```env
-# Template/context compatibility
-DOMAIN_NAME=
-SITE_OWNER=
-
-# Certbot
-EMAIL=
-DOMAIN=
-
-# Django settings
-SECRET_KEY=
-DEBUG=
-DJANGO_ALLOWED_HOSTS=
-DJANGO_CSRF_TRUSTED_ORIGINS=
-DJANGO_CORS_ALLOWED_ORIGINS=
-SQL_ENGINE=
-SQL_DATABASE=
-SQL_USER=
-SQL_PASSWORD=
-SQL_HOST=
-SQL_PORT=5432
-
-# DB settings
-POSTGRES_USER=
-POSTGRES_PASSWORD=
-POSTGRES_DB=
+```bash
+cp .env.example .env
 ```
+
+`DOMAIN` is used by both Certbot and the Nginx container; Nginx renders it into `server_name` and the Let's Encrypt certificate paths at container startup.
 
 ---
 
@@ -177,13 +156,21 @@ POSTGRES_DB=
 ### 1. Generate the initial SSL certificate
 
 Port `80` must be available for Certbot's standalone HTTP challenge.
+Load the `.env` values into the shell before running the one-off certificate command:
 
 ```bash
+set -a
+. ./.env
+set +a
+
 docker run -it --rm -p 80:80 --name certbot \
 -v "/etc/letsencrypt:/etc/letsencrypt" \
 -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
 certbot/certbot certonly --standalone \
--d <your-domain>
+-d "${DOMAIN}" \
+--email "${EMAIL}" \
+--agree-tos \
+--no-eff-email
 ```
 
 ### 2. Start the application stack
@@ -214,11 +201,18 @@ docker compose stop
 ### 2. Renew certificate
 
 ```bash
+set -a
+. ./.env
+set +a
+
 docker run -it --rm -p 80:80 --name certbot \
 -v "/etc/letsencrypt:/etc/letsencrypt" \
 -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
 certbot/certbot certonly --standalone \
--d <your-domain> \
+-d "${DOMAIN}" \
+--email "${EMAIL}" \
+--agree-tos \
+--no-eff-email \
 --force-renewal
 ```
 
@@ -237,6 +231,7 @@ Incoming traffic is handled as follows:
 - HTTP traffic arrives at Nginx on port `80`.
 - Nginx redirects configured domain traffic to HTTPS.
 - HTTPS traffic terminates at Nginx using mounted Let's Encrypt certificates.
+- Nginx renders `DOMAIN` from `.env` into its runtime configuration before startup.
 - Application requests are proxied to Gunicorn.
 - Django static assets are served by Nginx from `/static/`.
 - Uploaded media files are served by Nginx from `/media/`.
@@ -261,7 +256,6 @@ Editable site content is managed through Django Admin, including:
 
 ## Future Improvements
 
-- Replace hardcoded Nginx domain and certificate paths with environment-driven configuration.
 - Automate SSL certificate renewal.
 - Split Docker Compose development and production concerns into explicit profiles or separate compositions.
 - Add production frontend build and serving steps if the React app is to be served by the Docker/Nginx stack.

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -13,6 +13,16 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 import os
 from pathlib import Path
 
+
+def get_bool_env(name, default=False):
+    value = os.environ.get(name)
+
+    if value is None:
+        return default
+
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -23,7 +33,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = bool(os.environ.get("DEBUG", False))
+DEBUG = get_bool_env("DEBUG")
 
 ALLOWED_HOSTS = os.environ.get(
     "DJANGO_ALLOWED_HOSTS",

--- a/backend/config/test_settings.py
+++ b/backend/config/test_settings.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from config.settings import get_bool_env
+
+
+class GetBoolEnvTestCase(TestCase):
+    def test_returns_true_for_explicit_truthy_values(self):
+        for value in ("1", "true", "True", "yes", "on"):
+            with self.subTest(value=value), patch.dict("os.environ", {"SETTING_FLAG": value}):
+                self.assertTrue(get_bool_env("SETTING_FLAG"))
+
+    def test_returns_false_for_explicit_falsey_values(self):
+        for value in ("0", "false", "False", "no", "off", ""):
+            with self.subTest(value=value), patch.dict("os.environ", {"SETTING_FLAG": value}):
+                self.assertFalse(get_bool_env("SETTING_FLAG"))
+
+    def test_returns_default_for_missing_values(self):
+        with patch.dict("os.environ", {}, clear=True):
+            self.assertTrue(get_bool_env("SETTING_FLAG", default=True))
+            self.assertFalse(get_bool_env("SETTING_FLAG", default=False))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   frontend:
     image: node:20-alpine
@@ -52,7 +50,7 @@ services:
       - "/var/lib/letsencrypt:/var/lib/letsencrypt"
     env_file:
       - ./.env
-    command: certbot certonly --standalone -d ${DOMAIN}
+    command: certbot certonly --standalone -d ${DOMAIN} --email ${EMAIL} --agree-tos --no-eff-email
 
 volumes:
   postgres_data:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:1.25
 
 RUN rm /etc/nginx/conf.d/default.conf
-COPY nginx.conf /etc/nginx/conf.d
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -10,17 +10,17 @@ server {
 server {
     listen 80;
     listen [::]:80;
-    server_name your-domain.com;
+    server_name ${DOMAIN};
     return 301 https://$server_name$request_uri;
 }
 
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name your-domain.com;
+    server_name ${DOMAIN};
 
-    ssl_certificate /etc/letsencrypt/live/your-domain.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/your-domain.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
 
     ssl_session_cache shared:le_nginx_SSL:10m;
     ssl_session_timeout 1440m;


### PR DESCRIPTION
Configures Nginx to use deployment domain settings from environment variables instead of requiring manual replacement during production pulls.

Changes:
- Converts `nginx/nginx.conf` into a startup-rendered template used by the Nginx container.
- Uses `DOMAIN` for Nginx `server_name` and Lets Encrypt certificate paths.
- Adds tracked `.env.example` documentation with `<...>` placeholders.
- Documents `.env.example` usage and the `DOMAIN`/`EMAIL` deployment flow in `README.md`.
- Updates the Certbot Compose command to use `DOMAIN` and `EMAIL`.
- Parses Django `DEBUG` as an explicit boolean so `DEBUG=False` is safe in env files.
- Removes the obsolete Docker Compose `version` key.

Verification:
- backend: `pipenv run python manage.py test`
- frontend: `npm test`
- frontend: `npm run lint`
- frontend: `npm run build`
- `docker compose config` with `DOMAIN` and `EMAIL` supplied
- Nginx template render check with a sample `DOMAIN`