### PR TITLE
Demote project default status

### DIFF
--- a/backend/portfolio/models.py
+++ b/backend/portfolio/models.py
@@ -96,7 +96,7 @@ class Project(models.Model):
     public = models.BooleanField(default=True)
     featured = models.BooleanField(default=False)
     status = models.CharField(
-        default=Status.STABLE, choices=Status.choices, max_length=20
+        default=Status.PROTOTYPE, choices=Status.choices, max_length=20
     )
     display_order = models.PositiveIntegerField(
         default=0,


### PR DESCRIPTION
Intended as a safe-guard to not post a prototype or beta project as a fully mature project.